### PR TITLE
added chatgroup functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "expo-sqlite": "~11.1.1",
         "expo-status-bar": "~1.4.4",
         "js-base64": "^3.7.5",
-        "les-im-components": "^1.1.2",
+        "les-im-components": "^1.1.5",
         "lodash": "^4.17.21",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
@@ -9532,9 +9532,9 @@
       }
     },
     "node_modules/les-im-components": {
-      "version": "1.1.2",
-      "resolved": "http://3.96.234.252:4873/les-im-components/-/les-im-components-1.1.2.tgz",
-      "integrity": "sha512-1uxSdMrSapaz3HAm1ML4zUbajq2HqRcnGi4rOQFaXFNHNnMr1dnpxeYDfoTRtVQD88VU01Io1pIJCImwq74TVA==",
+      "version": "1.1.5",
+      "resolved": "http://3.96.234.252:4873/les-im-components/-/les-im-components-1.1.5.tgz",
+      "integrity": "sha512-cGuOP9J05Q11xsr0ZuDFrC9N7LcL2HJHg+SBj5p9mTkic84nA9h3hdcaMY6aUqEqNTs8z97/NqhWGNYjUvbdLQ==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expo-sqlite": "~11.1.1",
     "expo-status-bar": "~1.4.4",
     "js-base64": "^3.7.5",
-    "les-im-components": "^1.1.2",
+    "les-im-components": "^1.1.5",
     "lodash": "^4.17.21",
     "nativewind": "^2.0.11",
     "react": "18.2.0",

--- a/src/Models/ChatGroup.js
+++ b/src/Models/ChatGroup.js
@@ -1,5 +1,9 @@
 import IMUserInfo from "./IMUserInfo";
+import { LesConstants, LesPlatformCenter } from "les-im-components";
 
+const { IMGroupMemberRole, IMGroupMemberState, IMUserState, IMUserOnlineState } = LesConstants;
+
+const MemberUpdateDelay = 300000;
 /**
  * 聊天群组，存储的是聊天群组的基本信息，和成员列表，不存储聊天记录
  */
@@ -44,11 +48,115 @@ class ChatGroup {
      */
     latestTimelineId;
 
+    /**
+     * 组成员
+     * @type {ChatGroupMember[]}
+     */
+    #members;
+
+    /**
+     * 上一次更新成员列表的时间
+     * @type {number}
+     */
+    #lastMemberUpdateTime = 0;
+
+
     updateTimelineId(timelineId) {
         if (timelineId > this.latestTimelineId) {
             this.latestTimelineId = timelineId;
         }
     }
+
+    /**
+     * 
+     * @returns {Promise<ChatGroupMember[]>}
+     */
+    #updateMembers() {
+        return new Promise((resolve, reject) => {
+            if (this.#lastMemberUpdateTime == 0 || Date.now() - this.#lastMemberUpdateTime > MemberUpdateDelay) {
+                LesPlatformCenter.IMFunctions.getGroupMembers(this.id).then(list => {
+                    var members = list.map((v) => {
+                        const groupId = v.getGroupid();
+                        const memberId = v.getMemberinfo().getId();
+                        const memberName = v.getMemberinfo().getName();
+                        const memberTag = v.getMemberinfo().getTag();
+                        const memberState = v.getMemberstate();
+                        const memberRole = v.getMemberrole();
+                        const joinTime = v.getJointime();
+
+                        const member = new ChatGroupMember();
+                        member.set(groupId, memberId, memberName, memberTag, memberState, memberRole, joinTime);
+                        return member;
+                    });
+                    this.#members = members;
+                    resolve(this.#members);
+                }).catch(e => {
+                    reject(e);
+                })
+            } else {
+                resolve(this.#members);
+            }
+        });
+    }
+
+    /**
+     * 获取群组成员列表
+     * 注：不要使用这个方法获取成员列表，要用ChatGroupService.Inst.getGroupMembers方法
+     * @param {(state:IMGroupMemberState)=>boolean} stateFilter 状态过滤器，null表示获取全部状态
+     * @returns {Promise<ChatGroupMember[]>}
+     */
+    getMembers(stateFilter) {
+        return new Promise((resolve, reject) => {
+            this.#updateMembers().then(members => {
+                let ms = [];
+                if (stateFilter == null) {
+                    ms = members;
+                } else {
+                    ms = members.filter((v) => stateFilter(v))
+                }
+                resolve(ms);
+            }).catch(err => reject(err));
+        })
+    }
+
+}
+
+class ChatGroupMember {
+    /**
+     * @type {number}
+     */
+    groupId;
+
+    /**
+     * @type {IMGroupMemberRole}
+     */
+    memberRole;
+
+    /**
+     * @type {IMGroupMemberState}
+     */
+    groupState;
+
+    /**
+     * @type {number}
+     */
+    jointTime;
+
+    /**
+     * @type {IMUserInfo}}
+     */
+    userInfo;
+
+    set(groupId, userId, userName, userTag, memberState, memberRole, jointTime) {
+        this.groupId = groupId;
+        this.userInfo = new IMUserInfo(userId, userName, userTag, IMUserState.Online, IMUserOnlineState.Offline);
+        this.memberState = memberState;
+        this.memberRole = memberRole;
+        this.jointTime = jointTime;
+    }
+
 }
 
 export default ChatGroup;
+
+export { ChatGroupMember }

--- a/src/modules/DataCenter.js
+++ b/src/modules/DataCenter.js
@@ -5,6 +5,7 @@ import FriendData from "../Models/Friends";
 import MessageData from "../Models/MessageData";
 import { MessageCaches } from "../Models/MessageCaches";
 import { Notifications } from "../Models/Notifications";
+import IMUserInfo from "../Models/IMUserInfo";
 
 
 const services = [];
@@ -41,10 +42,9 @@ const DataCenter = {
 
     /**
      * im用户信息
+     * @type {IMUserInfo}
      */
-    imUserInfo: {
-      name: "", tag: 0, state: 0
-    }
+    imUserInfo: new IMUserInfo()
   },
 
   /**

--- a/src/services/ChatGroupService.js
+++ b/src/services/ChatGroupService.js
@@ -1,5 +1,5 @@
 import { LesConstants, LesPlatformCenter } from "les-im-components";
-import ChatGroup from "../Models/ChatGroup";
+import ChatGroup, { ChatGroupMember } from "../Models/ChatGroup";
 import { reject } from "lodash";
 import PBUtils from "../utils/PBUtils";
 import DatabaseService from "./DatabaseService";
@@ -8,12 +8,16 @@ import { DataEvents, UIEvents } from "../modules/Events";
 import { Notification, Notifications } from "../Models/Notifications";
 import MessageData from "../Models/MessageData";
 import DataCenter from "../modules/DataCenter";
+import IMUserInfoService from "./IMUserInfoService";
+import IMUserInfo from "../Models/IMUserInfo";
 
 const {
   IMUserState,
   IMUserOnlineState,
   IMNotificationType,
   IMNotificationState,
+  IMGroupMemberState,
+  IMGroupMemberRole,
 } = LesConstants;
 
 class ChatGroupService {
@@ -125,7 +129,7 @@ class ChatGroupService {
         cg.latestTimelineId = 0;
         this.#pushChatGroup(cg);
         this.#updateChatGroup(cg.id)
-          .then((cg) => {})
+          .then((cg) => { })
           .catch((err) =>
             console.error(`更新群[${cg.id}]失败，code：${err.toString(16)}`)
           );
@@ -138,7 +142,7 @@ class ChatGroupService {
     this.#chatGroups = {};
     try {
       const groups = await DatabaseService.Inst.loadChatGroup();
-      groups.forEach((cg) => (this.#chatGroups[cg.id] = cg));
+
       await this.requestChatGroupsTimeline();
     } catch (e) {
       console.error(`读取群组数据失败`, e);
@@ -187,6 +191,89 @@ class ChatGroupService {
           reject(e);
         });
     });
+  }
+
+  /**
+   * 获取指定聊天群组的详情数据
+   * @param {number} chatGroupId 
+   * @returns {Promise<ChatGroup>}
+   */
+  getChatGroup(chatGroupId) {
+    return this.#updateChatGroup(chatGroupId);
+  }
+
+  /**
+   * 获取群组成员列表
+   * @param {number} groupId 
+   * @param {(state:IMGroupMemberState)=>boolean} stateFilter 状态过滤器，null表示获取全部状态
+   * @returns {Promise<ChatGroupMember[]>}
+   */
+  getGroupMembers(groupId, stateFilter) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const group = await this.#updateChatGroup(groupId);
+        const members = await group.getMembers(stateFilter);
+
+        const ids = members.map((v) => v.userInfo.id);
+        const users = await IMUserInfoService.Inst.getUser(ids);
+
+        const userMap = {};
+
+        users.forEach(user => {
+          userMap[user.id] = user;
+        })
+
+        members.forEach(member => {
+          const userInfo = userMap[member.userInfo.id];
+          if (userInfo != null) {
+            member.userInfo = userInfo;
+          }
+        })
+
+        resolve(members);
+
+      } catch (err) {
+        reject(err);
+      }
+
+
+      this.#updateChatGroup(groupId).then(group => {
+        group.getMembers(stateFilter).then(ms => {
+
+          const ids = ms.map((v) => v.userInfo.id);
+          const users = IMUserInfoService.Inst.getUser(ids);
+
+        }).catch(err => reject(err));
+      }).catch(err => reject(err));
+    })
+  }
+
+  /**
+   * 退出群聊
+   * @param {number} groupId 
+   */
+  quitChatGroup(groupId) {
+    return new Promise((resolve, reject) => {
+      LesPlatformCenter.IMFunctions.quitGroup(groupId).then(id => {
+        this.#chatGroups[groupId] = null;
+        delete this.#chatGroups[groupId];
+        DatabaseService.Inst.removeChatGroup(groupId);
+        resolve(id);
+      }).catch(err => reject(err));
+    })
+  }
+
+  /**
+   * 移除群内成员
+   * @param {number} groupId 
+   * @param {number} memberId 
+   */
+  removeGroupMember(groupId, memberId) {
+    return new Promise((resolve, reject) => {
+      LesPlatformCenter.IMFunctions.removeGroupMember(groupId, memberId).then(removedUserId => {
+        resolve(removedUserId);
+      }).catch(err => reject(err));
+    })
   }
 }
 

--- a/src/services/DataSavingService.js
+++ b/src/services/DataSavingService.js
@@ -17,6 +17,7 @@ import { LesConstants } from "les-im-components";
 import MessageData from "../Models/MessageData";
 import DatabaseService from "./DatabaseService";
 import { MessageCaches } from "../Models/MessageCaches";
+import IMUserInfo from "../Models/IMUserInfo";
 const IMUserState = LesConstants.IMUserState;
 
 class DataSavingService {
@@ -123,7 +124,10 @@ class DataSavingService {
     DataCenter.userInfo.accountId = id;
     DataCenter.userInfo.loginKey = key;
     DataCenter.userInfo.email = email;
-    DataCenter.userInfo.imUserInfo = imUserInfo;
+
+    const userInfo = new IMUserInfo(id, imUserInfo.name, imUserInfo.tag, imUserInfo.state, LesConstants.IMUserOnlineState.Online);
+
+    DataCenter.userInfo.imUserInfo = userInfo;
   }
 
   /**

--- a/src/services/DatabaseService.js
+++ b/src/services/DatabaseService.js
@@ -701,6 +701,19 @@ export default class DatabaseService {
     })
   }
 
+  removeChatGroup(groupId) {
+    if (this.#currDb == null) reject(ERROR_DB_ISNULL);
+    this.#currDb.transaction((tx) => {
+      tx.executeSql(
+        "delete from tbl_chatgroup where groupId = ?", [groupId],
+        (_, r) => resolve(groupId),
+        (_, e) => {
+          reject(e);
+        }
+      )
+    });
+  }
+
   loadMessage() {
     return new Promise((resolve, reject) => {
       if (this.#currDb == null) reject(ERROR_DB_ISNULL);


### PR DESCRIPTION
les-im-components更新到1.1.5版本，需要npm install les-im-components

① IMUserInfoService的getUser方法发生变化，现在返回一个Promise，相关调用部分需要修改
② IMUserInfoService新增setCurrentUserState方法，设置当前用户的状态，原先调用LesPlatformCenter.IMFunctions.setState的地方，需要改为调用这个方法，都是相同的Promise
③ ChatGroupService新增getChatGroup方法，返回group相关信息
④ ChatGroupService新增getGroupMembers方法，返回group的成员列表
⑤ ChatGroupService新增quitChatGroup方法，退出群聊
⑥ ChatGroupService新增removeGroupMember方法，踢出成员，注意此处reject的返回code，需要做提示，例如权限不足等

待添加：
群组成员被邀请入群，离开群聊的通知，类似微信群聊中的提示 xxx邀请xxx加入了群聊