### PR TITLE
added group functions: quit & remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "expo-sqlite": "~11.1.1",
         "expo-status-bar": "~1.4.4",
         "js-base64": "^3.7.5",
-        "les-im-components": "^1.1.7",
+        "les-im-components": "^1.1.8",
         "lodash": "^4.17.21",
         "nativewind": "^2.0.11",
         "react": "18.2.0",
@@ -9532,9 +9532,9 @@
       }
     },
     "node_modules/les-im-components": {
-      "version": "1.1.7",
-      "resolved": "http://3.96.234.252:4873/les-im-components/-/les-im-components-1.1.7.tgz",
-      "integrity": "sha512-S8eCmeM8htORWx+/gSjJ4LCvqqHbpCgmcnPTQ+OL9Zu+WZl5xOaOho8NSIi+dX4IA+Hw7XqOTDpTamrQ3hzfOg==",
+      "version": "1.1.8",
+      "resolved": "http://3.96.234.252:4873/les-im-components/-/les-im-components-1.1.8.tgz",
+      "integrity": "sha512-yeBtUebvlMZ7TmfwMW2OFJQ69PMaaUivegTaA1Ulvt1cniSHev7eK9+LLp5DBmSIoUzdfi9w0s5kY3oRxtzyEw==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expo-sqlite": "~11.1.1",
     "expo-status-bar": "~1.4.4",
     "js-base64": "^3.7.5",
-    "les-im-components": "^1.1.7",
+    "les-im-components": "^1.1.8",
     "lodash": "^4.17.21",
     "nativewind": "^2.0.11",
     "react": "18.2.0",

--- a/src/modules/Events.js
+++ b/src/modules/Events.js
@@ -102,6 +102,13 @@ export const DataEvents = {
      * 群数据更新后，会发送此事件
      */
     ChatGroup_Updated: "DATA_EVENT_ChatGroup_ChatGroup_Updated",
+
+    /**
+     * 被移出群聊
+     * @type {groupId:number}
+     */
+    ChatGroup_RemovedFromGroup: "DATA_EVENT_ChatGroup_ChatGroup_RemovedFromGroup"
+
   },
 
   Saving: {

--- a/src/services/NotificationService.js
+++ b/src/services/NotificationService.js
@@ -77,6 +77,26 @@ class NotificationService {
   }
 
   /**
+   * 取消一个邀请，只能取消发起人发起的邀请
+   * @param {number} notificationId 
+   */
+  cancelInvitation(notificationId) {
+    return new Promise((resolve, reject) => {
+      LesPlatformCenter.IMFunctions.respondNotification(
+        notificationId,
+        IMNotificationState.Canceled
+      )
+        .then((id) => {
+          //调用成功后续不用做处理，客户端会收到服务器发来的最新状态的通知，由onRecvNotification处理
+          resolve(id);
+        })
+        .catch((e) => {
+          reject(e);
+        });
+    });
+  }
+
+  /**
    * 响应指定id的通知消息
    * @deprecated 直接调用 respondInvitation 方法
    * @param {number} notificationId


### PR DESCRIPTION
① les-im-components更新，需要npm install les-im-components
②ChatGroupService.js新增 quitGroup和removeGroupMember方法，可以退出群聊和移除成员
③NotificationService.js新增cancelInvitation方法，可以取消已发出的邀请
注：
④新增 DataEvents.ChatGroup.ChatGroup_RemovedFromGroup事件，事件参数为 groupId:number， 当前用户被踢出某个群后，会触发这个事件，需要从ui中移除对应的群聊